### PR TITLE
Use a single global infinite promise

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,6 @@
 import React, { Suspense, Fragment } from "react";
 
-const infinitePromise = new Promise(
-  // @ts-ignore
-  (resolve) => {}
-);
+const infiniteThenable = { then() {} };
 
 function Suspender({
   freeze,
@@ -13,7 +10,7 @@ function Suspender({
   children: React.ReactNode;
 }) {
   if (freeze) {
-    throw infinitePromise;
+    throw infiniteThenable;
   }
   return <Fragment>{children}</Fragment>;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,9 @@
-import React, { useRef, Suspense, Fragment } from "react";
+import React, { Suspense, Fragment } from "react";
 
-interface StorageRef {
-  promise?: Promise<void>;
-  resolve?: (value: void | PromiseLike<void>) => void;
-}
+const infinitePromise = new Promise(
+  // @ts-ignore
+  (resolve) => {}
+);
 
 function Suspender({
   freeze,
@@ -12,19 +12,9 @@ function Suspender({
   freeze: boolean;
   children: React.ReactNode;
 }) {
-  const promiseCache = useRef<StorageRef>({}).current;
-  if (freeze && !promiseCache.promise) {
-    promiseCache.promise = new Promise((resolve) => {
-      promiseCache.resolve = resolve;
-    });
-    throw promiseCache.promise;
-  } else if (freeze) {
-    throw promiseCache.promise;
-  } else if (promiseCache.promise) {
-    promiseCache.resolve!();
-    promiseCache.promise = undefined;
+  if (freeze) {
+    throw infinitePromise;
   }
-
   return <Fragment>{children}</Fragment>;
 }
 


### PR DESCRIPTION
It's not super clear why the code is written this way, but I assume it's due to not being familiar with the pattern. If you want to wait until the `freeze` prop changes, it's enough to throw a Promise that never resolves.

This fixes an issue that would occur on initial mount with `createRoot` and/or Fabric. The issue is that React throws away uncommitted trees if they suspend during mount, and this includes throwing away `useRef`. So stashing Promises in `useRef` is wrong. Having one at the top level is both safe and simpler.