### PR TITLE
Use Offscreen api instead of suspense to avoid infinite loop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ const OffscreenType = Symbol.for('react.offscreen');
 export function Freeze({ freeze, children }) {
   return React.createElement(
     OffscreenType,
-    { mode: freeze ? 'hidden' : 'visible' },
+    { mode: freeze ? 'unstable-defer-without-hiding' : 'visible' },
     children,
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,30 +1,11 @@
-import React, { Suspense, Fragment } from "react";
+import React from "react";
 
-const infiniteThenable = { then() {} };
+const OffscreenType = Symbol.for('react.offscreen');
 
-function Suspender({
-  freeze,
-  children,
-}: {
-  freeze: boolean;
-  children: React.ReactNode;
-}) {
-  if (freeze) {
-    throw infiniteThenable;
-  }
-  return <Fragment>{children}</Fragment>;
-}
-
-interface Props {
-  freeze: boolean;
-  children: React.ReactNode;
-  placeholder?: React.ReactNode;
-}
-
-export function Freeze({ freeze, children, placeholder = null }: Props) {
-  return (
-    <Suspense fallback={placeholder}>
-      <Suspender freeze={freeze}>{children}</Suspender>
-    </Suspense>
+export function Freeze({ freeze, children }) {
+  return React.createElement(
+    OffscreenType,
+    { mode: freeze ? 'hidden' : 'visible' },
+    children,
   );
 }


### PR DESCRIPTION
In one of Margelo projects I noticed that there is an infinite loop after I open and close a certain screen.
I'm currently on RN 78 with fabric on but not in bridgeless. That means that my project uses Legacy runtimeScheduler. 
What I observed was that work loop in the legacy scheduler never finishes after that certain screen is opened.
Looks like the loop is caused by react pinging suspended lanes. I always thought that react re-renders after the thrown promise is resolved but that doesn't seems to be the case. It's just endlessly poling until the promise is resolved. As we on purpose freeze the component it will Never resolve unless we go back to that frozen screen. 

As a solution I changed the current implementation with @SudoPlz to use the offscreen api and avoid the endless loop.

@kmagiera What do you think about this change? Happy to hop on a call anytime :)

Here are the methods that causes the infinite loop:
<img width="630" height="262" alt="Screenshot 2025-07-21 at 20 48 43" src="https://github.com/user-attachments/assets/f35a03d6-52da-4bb5-ae58-859fb62190fe" />
<img width="584" height="430" alt="Screenshot 2025-07-21 at 20 49 13" src="https://github.com/user-attachments/assets/5aaf9eca-a9c6-4703-9c60-306b0eb58a58" /> (As we still have suspended lanes as reschedule)
<img width="759" height="107" alt="Screenshot 2025-07-21 at 20 49 56" src="https://github.com/user-attachments/assets/fbdf9b11-d9ee-4c16-b64d-969fd7fe1262" />
