### PR TITLE
fix(breaking): migrate to `use()` to fix endless loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "freeze"
   ],
   "peerDependencies": {
-    "react": ">=17.0.0"
+    "react": ">=19.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.4",
     "@types/node": "^12.12.38",
-    "@types/react": "^18.0.15",
-    "@types/react-test-renderer": "^18.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-test-renderer": "^19.0.0",
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
     "babel-eslint": "^10.0.3",
@@ -51,7 +51,7 @@
     "microbundle-crl": "^0.13.10",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4",
-    "react": "^18.2.0",
+    "react": "^19.2.0",
     "react-scripts": "^3.4.1",
     "react-test-renderer": "^18.2.0",
     "typescript": "^3.7.5"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ function Suspender({ freeze, children }: SuspenderProps) {
   if (!freeze && resolverRef.current != null) {
     // Un-freeze: call the resolver to resolve the promise and un-suspend.
     resolverRef.current();
+    resolverRef.current = null;
   }
 
   if (promiseRef.current !== null) {
@@ -30,7 +31,6 @@ function Suspender({ freeze, children }: SuspenderProps) {
     // Only reset promise here, as when un-freezing we want to "ping the attached listeners" that the promise is resolved.
     // Thats why we call the resolver above when !freeze.
     promiseRef.current = null;
-    resolverRef.current = null;
   }
 
   return <Fragment>{children}</Fragment>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,4 @@
-import React, { Suspense, Fragment } from "react";
-
-const infiniteThenable = { then() {} };
+import React, { Suspense, Fragment, use } from "react";
 
 interface SuspenderProps {
   freeze: boolean;
@@ -8,9 +6,30 @@ interface SuspenderProps {
 }
 
 function Suspender({ freeze, children }: SuspenderProps) {
-  if (freeze) {
-    throw infiniteThenable;
+  const resolverRef = React.useRef<(() => void) | undefined>(undefined);
+  const promiseRef = React.useRef<Promise<void> | null>(null);
+
+  if (promiseRef.current === null && freeze) {
+    promiseRef.current = new Promise<void>((resolve) => {
+      resolverRef.current = resolve;
+    });
   }
+
+  if (!freeze && resolverRef.current != null) {
+    resolverRef.current();
+  }
+
+  if (promiseRef.current !== null) {
+    use(promiseRef.current);
+  }
+
+  if (!freeze) {
+    // Only reset promise here, as when un-freezing we want to "ping the attached listeners" that the promise is resolved.
+    // Thats why we call the resolver above when !freeze.
+    promiseRef.current = null;
+    resolverRef.current = undefined;
+  }
+
   return <Fragment>{children}</Fragment>;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,9 +6,10 @@ interface SuspenderProps {
 }
 
 function Suspender({ freeze, children }: SuspenderProps) {
-  const resolverRef = React.useRef<(() => void) | undefined>(undefined);
-  const promiseRef = React.useRef<Promise<void> | null>(null);
-
+  // Create a stable promise which we can later use to suspend the component.
+  const promiseRef = React.useRef<Promise<void>>(null);
+  // Ref to store the promise's resolver function, to be called when un-freezing.
+  const resolverRef = React.useRef<() => void>(null);
   if (promiseRef.current === null && freeze) {
     promiseRef.current = new Promise<void>((resolve) => {
       resolverRef.current = resolve;
@@ -16,10 +17,12 @@ function Suspender({ freeze, children }: SuspenderProps) {
   }
 
   if (!freeze && resolverRef.current != null) {
+    // Un-freeze: call the resolver to resolve the promise and un-suspend.
     resolverRef.current();
   }
 
   if (promiseRef.current !== null) {
+    // Suspend by using the promise, or when promise resolved it un-suspends.
     use(promiseRef.current);
   }
 
@@ -27,7 +30,7 @@ function Suspender({ freeze, children }: SuspenderProps) {
     // Only reset promise here, as when un-freezing we want to "ping the attached listeners" that the promise is resolved.
     // Thats why we call the resolver above when !freeze.
     promiseRef.current = null;
-    resolverRef.current = undefined;
+    resolverRef.current = null;
   }
 
   return <Fragment>{children}</Fragment>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2734,10 +2734,10 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
-"@types/react-test-renderer@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
-  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
+"@types/react-test-renderer@^19.0.0":
+  version "19.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz#1d0af8f2e1b5931e245b8b5b234d1502b854dc10"
+  integrity sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==
   dependencies:
     "@types/react" "*"
 
@@ -2750,14 +2750,12 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^18.0.15":
-  version "18.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.15.tgz#d355644c26832dc27f3e6cbf0c4f4603fc4ab7fe"
-  integrity sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==
+"@types/react@^19.0.0":
+  version "19.2.7"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.7.tgz#84e62c0f23e8e4e5ac2cadcea1ffeacccae7f62f"
+  integrity sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==
   dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
+    csstype "^3.2.2"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -4956,6 +4954,11 @@ csstype@^3.0.2:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
   integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
+
+csstype@^3.2.2:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
+  integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -10965,12 +10968,10 @@ react-test-renderer@^18.2.0:
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
 
-react@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
-  dependencies:
-    loose-envify "^1.1.0"
+react@^19.2.0:
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.0.tgz#d33dd1721698f4376ae57a54098cb47fc75d93a5"
+  integrity sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Problem

In a clients react-native app, using new arch bridgeless, we noticed an occasion where without the user doing anything react was entering an infinite rendering loop.
React concurrently working on a lane, that lane would suspend, it would try to work on another lane which would also suspend and so on.

I added logs in react which would look something like this:

<details>
  <summary>Logs inside of `ReactFiberWorkLoop.js`</summary>

  ```shell
[PERFORM WORK START] {"forceSync": false, "lanes": 8388608, "pendingLanes": 25165824, "suspendedLanes": 16777216}
[RENDER START CONCURRENT] {"lanes": 8388608, "shellSuspendCounter": 0, "suspendedLanes": 16777216, "timestamp": 1764236797188}
[SUSPENSE BOUNDARY] {"componentName": "Anonymous", "didSuspend": false, "flags": 0, "memoizedState": {"dehydrated": null, "hydrationErrors": null, "retryLane": 0, "treeContext": 
null}}

# encountering a freeze component that would freeze and cause suspend
[THROW EXCEPTION DETAILED] {"boundaryMode": 3, "currentLanes": 8388608, "hasSuspenseBoundary": true, "parentChain": ["Tag22", "Tag13", "Freeze", "DelayedFreeze", "Tag11"], 
"promiseHasStatus": false, "promiseIsInfiniteThenable": true, "promiseStatus": undefined, "rootPendingLanes": 25165824, "rootSuspendedLanes": 16777216, "sourceFiberTag": 0, "sourceFiberType": 
"Suspender", "stackDepth": 5}
[SUSPENSE BOUNDARY] {"componentName": "Anonymous", "didSuspend": true, "flags": 16528, "memoizedState": null}
[UPDATE HOST CONTAINER] completeRoot {"containerTag": 1, "newChildSet": {}}
[SCHEDULE ROOT] {"pendingLanes": 50331648, "pingedLanes": 0, "suspendedLanes": 33554432}
[SCHEDULE ROOT] {"pendingLanes": 50331648, "pingedLanes": 0, "suspendedLanes": 33554432}
[PERFORM WORK END] {"lanes": 8388608, "pendingLanes": 50331648, "suspendedLanes": 33554432}

# encountering freeze again, this time DelayedFreeze is gone
[PERFORM WORK START] {"forceSync": false, "lanes": 16777216, "pendingLanes": 50331648, "suspendedLanes": 33554432}
[RENDER START CONCURRENT] {"lanes": 16777216, "shellSuspendCounter": 0, "suspendedLanes": 33554432, "timestamp": 1764236797196}
[SUSPENSE BOUNDARY] {"componentName": "Anonymous", "didSuspend": false, "flags": 0, "memoizedState": {"dehydrated": null, "hydrationErrors": null, "retryLane": 0, "treeContext": 
null}}
[THROW EXCEPTION DETAILED] {"boundaryMode": 3, "currentLanes": 16777216, "hasSuspenseBoundary": true, "parentChain": ["Tag22", "Tag13", "Freeze", "Tag5", "Tag11"], "promiseHasStatus":
 false, "promiseIsInfiniteThenable": true, "promiseStatus": undefined, "rootPendingLanes": 50331648, "rootSuspendedLanes": 33554432, "sourceFiberTag": 0, "sourceFiberType": "Suspender", "stackDepth": 
1}
[SUSPENSE BOUNDARY] {"componentName": "Anonymous", "didSuspend": true, "flags": 16528, "memoizedState": null}
[UPDATE HOST CONTAINER] completeRoot {"containerTag": 1, "newChildSet": {}}
[SCHEDULE ROOT] {"pendingLanes": 37748736, "pingedLanes": 0, "suspendedLanes": 4194304}
[SCHEDULE ROOT] {"pendingLanes": 37748736, "pingedLanes": 0, "suspendedLanes": 4194304}
[PERFORM WORK END] {"lanes": 16777216, "pendingLanes": 37748736, "suspendedLanes": 4194304}
// ... and so one, forever
 ```
</details>


The problem is that this would call completeRoot/Surface every very milliseconds:

<details>
<summary>Screenshots of CPU sample profiler + react devtools</summary>

<img width="1509" height="738" alt="Screenshot 2025-11-24 at 14 16 40" src="https://github.com/user-attachments/assets/b9c99156-1f71-4ee1-a951-c783cffde9d0" />
<img width="1511" height="758" alt="Screenshot 2025-11-24 at 14 16 06" src="https://github.com/user-attachments/assets/2ea56b4a-b6fa-4d61-a67e-4e77ce93a6ec" />

Over 1.000 commits in a few seconds:
<img width="635" height="63" alt="Screenshot_2025-11-25_at_13 35 09" src="https://github.com/user-attachments/assets/dc08be69-34d9-4a71-baea-5cf2d0d442fa" />

And it would actually hit the mounting layer natively:

https://github.com/user-attachments/assets/25b914e5-9f80-4ffe-bfd6-8ac466d2476d

</details>


This basically caused our app's CPU usage to spike around a 100%:

<details>
<summary>JS thread CPU + memory graph during loop</summary>

Taken while this bug occurred: 
<img width="1610" height="945" alt="Screenshot 2025-11-14 at 16 48 47" src="https://github.com/user-attachments/assets/ba80add0-ad15-45eb-804d-360858a5b070" />

</details>

> Note: the app wouldn't freeze in that loop, as that happens as part of react's concurrent rendering, the user is able to break out of that loop by scheduling any other kind of higher priority sync re-render.

## The fix

I didn't fully root cause the issue in the react-reconciler. I tried reproducing it with just `react-freeze` / suspense but had no luck. From my logs i noticed that the involvement of the [`<DelayedFreeze>`](https://github.com/software-mansion/react-native-screens/blob/main/src/components/helpers/DelayedFreeze.tsx) component from react-native-screens seems to be important for reproducing this. I tried to build a reproduction with that too and had no luck.
I am happy though to connect one of your team to test the bug happening in the clients app.

While looking through the react-reconciler code to understand how this could happen I noticed that for suspending there are two code paths:

- Legacy one: throwing a promise. This is what react-freeze is currently doing
- Officially supported one: using the `use()` function

One problem seems to be around how react-freeze is throwing a never ending promise, while react tries to attach a "listener" on our promise to get pinged once the promise resolves to continue working on that lane. This is something that react-freeze's infinite promise throwing is certainly preventing.

Interestingly though, my first fix implementation was to just throw a stable promise. The bug would happen less often, but still happen.

Only when i switched to the official `use()` API it stopped happening. I can only assume that's due to the slightly different code paths in the react reconciler.

## Caveats

With this change react-freeze requires react >= 19, due to this it would be a breaking change and major version bump.

## Testing

To be fair, i feel more happy with this change using the official APIs. And i think its nicer performance wise, as react will be pinged about when it can continue rendering instead of endlessly trying to render the frozen suspended part of the tree
(we reported a similar problem with the react-native RuntimeScheduler_Legacy [here](https://github.com/software-mansion/react-freeze/pull/39))

<details>
  <summary>I tested this change with this sample code:</summary>

  ```tsx
import React, {Suspense} from 'react';
import {Text, Button, View, AppRegistry} from 'react-native';
import {Freeze} from 'react-freeze';

let resolve: VoidFunction;
const promise = new Promise<void>((r) => {
  resolve = r;
});
let status = 'pending';
setTimeout(() => {
  resolve();
  status = 'success';
}, 3000);

function NestedChildThatSuspendsButResolves() {
  if (status === 'pending') {
    throw promise;
  }

  return <Text>Here is the async data!</Text>;
}

function ComponentThatFreezes() {
  const [counter, setCounter] = React.useState(0);

  React.useEffect(() => {
    const interval = setInterval(() => {
      setCounter((c) => c + 1);
    }, 1000);
    return () => clearInterval(interval);
  }, []);

  console.log('ComponentThatFreezes render with counter:', counter);

  return (
    <View>
      <Text>Counter: {counter}</Text>

      <Suspense>
        <NestedChildThatSuspendsButResolves />
      </Suspense>
    </View>
  );
}

function ReproductionApp() {
  const [isFrozen, setIsFrozen] = React.useState(false);

  return (
    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'white'}}>
      <Button
        title="Press me"
        onPress={() => {
          setIsFrozen((prev) => !prev);
        }}
      />

      <Freeze freeze={isFrozen} placeholder={<View style={{width: 40, height: 20, backgroundColor: 'aliceblue'}} />}>
        <ComponentThatFreezes />
      </Freeze>
    </View>
  );
}

AppRegistry.registerComponent('Discord', () => ReproductionApp);

  ```
</details>

 I was able to confirm that:

<details>
<summary><b>State updates still happened (inside react):</b></summary>

<img width="1230" height="575" alt="Screenshot 2025-11-28 at 10 20 09" src="https://github.com/user-attachments/assets/4625403d-e212-474b-b053-08e5b239c483" />
</details>


<details>
<summary><b>Mounting layer wasn't rendering the changes:</b></summary>

The part of the tree basically gets replaced by react/fabric with rendering a `View display=none`:

<img width="634" height="209" alt="Screenshot 2025-11-28 at 10 19 33" src="https://github.com/user-attachments/assets/69ad5214-2a49-4768-a87f-a7ab4f1e0ccf" />
</details>

Full recording with all logs of the test run:

https://github.com/user-attachments/assets/00666d9a-9965-4765-92bf-8c856705fa8e

And most importantly in the client's app the infinite loop was gone 🎊 